### PR TITLE
added sockets php extension

### DIFF
--- a/docker/php/7.3/fpm/debian/Dockerfile
+++ b/docker/php/7.3/fpm/debian/Dockerfile
@@ -48,6 +48,7 @@ RUN         curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash \
                 bcmath \
                 gd \
                 intl \
+                sockets \
                 opcache \
                 pdo_mysql \
                 soap \


### PR DESCRIPTION
Currently it is not possible to install Magento (tried 2.4-develop) by cloning Magento repository because of some missing PHP extensions in PHP docker image. 
This PR adds "sockets" php extension with a hope that composer install command will execute without errors.
