### PR TITLE
Update dockerfile (php7-fileinfo ext)

### DIFF
--- a/docker/php/7.3/fpm/alpine/Dockerfile
+++ b/docker/php/7.3/fpm/alpine/Dockerfile
@@ -20,7 +20,6 @@ RUN         apk update && \
                 php7-ctype \
                 php7-curl \
                 php7-dom \
-                php7-fileinfo \
                 php7-fpm \
                 php7-gd \
                 php7-gettext \
@@ -87,6 +86,9 @@ RUN         apk update && \
             \
             \
             chmod +x /php-fpm
+
+
+RUN apk add php7-fileinfo
 
 ENTRYPOINT  /php-fpm
 


### PR DESCRIPTION
php7-fileinfo is a required library on Magento 2.
If missing it's not possible to upload media images on project.
By this way php7-fileinfo is really installed.