### PR TITLE
chnage FROM  php:7.3-fpm -> php:7.2-fpm

### DIFF
--- a/docker/php/7.2/fpm-xdebug/debian/Dockerfile
+++ b/docker/php/7.2/fpm-xdebug/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM        php:7.3-fpm
+FROM        php:7.2-fpm
 
 LABEL       maintainer="Mage2click, Dmitry Shkoliar @shkoliar"
 


### PR DESCRIPTION
php-7.2-xdebug container uses php-7.3 
https://github.com/mage2click/m2c/issues/41
