### PR TITLE
#44 OpenSSL error with password to short minimal 4 chars - Mac OS Catelina

### DIFF
--- a/.m2c/functions/m2c
+++ b/.m2c/functions/m2c
@@ -3455,12 +3455,7 @@ m2c_sign() {
             -subj "/O=Mage2click/OU=IT/CN=${m2c_domains[0]}" >"${m2c_log}" 2>&1
         m2c_result $?
 
-        if [[ "$m2c_os" == "darwin" ]]
-        then
-            pass="m2c"
-        else
-            pass="m2c0"
-        fi
+        pass="m2c0"
 
         m2c_dots "Signing SSL certificate"
         m2c_loading

--- a/m2c
+++ b/m2c
@@ -481,12 +481,7 @@ m2c_install() {
     then
         m2c_info_bold "\n[Installing CA certificate]\n\n"
 
-        if [[ "$m2c_os" == "darwin" ]]
-        then
-            pass="m2c"
-        else
-            pass="m2c0"
-        fi
+        pass="m2c0"
 
         m2c_dots "Generating private key for CA certificate"
         m2c_loading


### PR DESCRIPTION
Removed darwin check with 3 chars password because of updated OpenSSL requires minimum 4 chars